### PR TITLE
feat: ignore query params in normalised url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist
 *.swp
 docs/_build
 .python-version
+.DS_Store
+.venv

--- a/aerostatsd/django/_transform.py
+++ b/aerostatsd/django/_transform.py
@@ -2,7 +2,7 @@ from urllib.parse import urlparse
 from uuid import UUID
 
 
-def normalize_url_path(url: str) -> str:
+def normalize_url_path(url: str, include_query_params: bool = True) -> str:
     """
     'Normalizes' a URL's path
 
@@ -19,6 +19,9 @@ def normalize_url_path(url: str) -> str:
     ----------
     url
         The URL path to normalize
+
+    include_query_params
+        Whether to include query parameters in the normalized path
 
     Returns
     -------
@@ -39,7 +42,7 @@ def normalize_url_path(url: str) -> str:
             normalized_path_parts.append(p)
 
     normalized_path = "/".join(normalized_path_parts)
-    if query:
+    if query and include_query_params:
         normalized_path = f"{normalized_path}?{query}"
 
     return normalized_path

--- a/aerostatsd/django/middleware.py
+++ b/aerostatsd/django/middleware.py
@@ -24,7 +24,7 @@ class StatsdMiddleware:
 
         tags = {
             "service": self.service_name,
-            "path": normalize_url_path(request.get_full_path()),
+            "path": normalize_url_path(request.get_full_path(), include_query_params=False),
             "method": request.method,
             "status": response.status_code,
             "environment": self.environment

--- a/aerostatsd/tests.py
+++ b/aerostatsd/tests.py
@@ -1147,3 +1147,8 @@ def test_normalize_path_two_nested_uuid_with_query_params():
     path = "/gateway/treesurveys/5e88b90c-c343-48cf-a140-35a3d5187dd7/trees/e82b6eb7-4832-4b06-900a-0e5d140e8031/?with_trees=false"
     normalized_path = normalize_url_path(path)
     eq_(normalized_path, "/gateway/treesurveys/{uuid}/trees/{uuid}/?with_trees=false")
+
+def test_normalize_path_ignore_query_params():
+    path = "/gateway/treesurveys/12345/?with_trees=false"
+    normalized_path = normalize_url_path(path, include_query_params=False)
+    eq_(normalized_path, "/gateway/treesurveys/{id}/")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aero-statsd
-version = 2.2.0
+version = 2.3.0
 author = Aerobotics
 author_email = nic@aerobotics.com
 description = A statsd client with support for Graphite tags


### PR DESCRIPTION
I don't see any queries with query params showing up on Grafana. I suspect it's something to do with query params. I'm keen to just leave them off the request path. 